### PR TITLE
Feat #91: Подписка на новые сообщения

### DIFF
--- a/frontend/common.blocks/chat-input/__emoji-button/chat-input__emoji-button.styl
+++ b/frontend/common.blocks/chat-input/__emoji-button/chat-input__emoji-button.styl
@@ -3,7 +3,7 @@
     right 0
     bottom 0
     height 50px
-    width 40px
+    width 50px
 
     // Временно:
     line-height 50px

--- a/frontend/common.blocks/dialog/dialog.deps.js
+++ b/frontend/common.blocks/dialog/dialog.deps.js
@@ -11,6 +11,7 @@
         { block : 'avatar', mods : { 'size' : 'm' } },
         { block : 'i-users' },
         { block : 'spin', mods : { theme : 'shriming', size : 'xl' } },
-        { block : 'notify' }
+        { block : 'notify' },
+        { block : 'events', elems : 'channels' }
     ]
 });

--- a/frontend/common.blocks/list/__counter/list__counter.bemhtml
+++ b/frontend/common.blocks/list/__counter/list__counter.bemhtml
@@ -1,0 +1,7 @@
+block('list').elem('counter')(
+    content()(function(){
+        var count = Number(this.ctx.count);
+
+        return (count === 0) ? '' : count;
+    })
+);

--- a/frontend/common.blocks/list/__counter/list__counter.styl
+++ b/frontend/common.blocks/list/__counter/list__counter.styl
@@ -1,0 +1,8 @@
+.list__counter
+    display inline-block
+    float right
+    padding 0 5px
+    border-radius 13px
+
+    background-color tomato
+    color whitesmoke

--- a/frontend/common.blocks/list/__counter/list__counter.styl
+++ b/frontend/common.blocks/list/__counter/list__counter.styl
@@ -1,8 +1,8 @@
 .list__counter
     display inline-block
-    float right
     padding 0 5px
+    font-size 12px
     border-radius 13px
-
+    vertical-align middle
     background-color tomato
     color whitesmoke

--- a/frontend/common.blocks/list/__item/_type/list__item_type_channels.styl
+++ b/frontend/common.blocks/list/__item/_type/list__item_type_channels.styl
@@ -3,3 +3,6 @@
         content '#'
         margin-right 2px
         color $gray_text_color
+
+    .list__counter
+        float right

--- a/frontend/common.blocks/list/__item/_type/list__item_type_users.styl
+++ b/frontend/common.blocks/list/__item/_type/list__item_type_users.styl
@@ -1,6 +1,10 @@
 .list__item_type_users
     height 38px
 
+    .user
+        vertical-align middle
+        width 91%
+
     .user__title, .user__nick
         width 146px
         overflow hidden

--- a/frontend/common.blocks/list/__item/list__item.bemhtml
+++ b/frontend/common.blocks/list/__item/list__item.bemhtml
@@ -1,1 +1,15 @@
-block('list').elem('item').tag()('li');
+block('list').elem('item')(
+    tag()('li'),
+    content()(function(){
+        var content = applyNext();
+
+        return [
+            content,
+            {
+                block : 'list',
+                elem : 'counter',
+                content : ''
+            }
+        ];
+    })
+);

--- a/frontend/common.blocks/list/list.deps.js
+++ b/frontend/common.blocks/list/list.deps.js
@@ -1,6 +1,6 @@
 ({
     mustDeps : [
-        { elems : ['title', 'container', 'item', 'spin'] }
+        { elems : ['title', 'container', 'item', 'spin', 'counter'] }
     ],
     shouldDeps : [
         { block : 'avatar' },
@@ -8,6 +8,7 @@
         { block : 'list', elem : 'item', mods : { type : ['channels', 'users'] } },
         { block : 'user' },
         { block : 'spin', mods : { theme : 'shriming', size : 's' } },
-        { block : 'notify' }
+        { block : 'notify' },
+        { block : 'events', elems : 'channels' },
     ]
 });

--- a/frontend/common.blocks/list/list.js
+++ b/frontend/common.blocks/list/list.js
@@ -16,35 +16,6 @@ modules.define(
                             spinBlock.setMod('visible');
                         }
 
-                        var _this = this;
-
-                        switch(_this.getMod('type')) {
-                            case 'channels':
-                                this._getChannelsData();
-                                break;
-
-                            case 'users':
-                                chatAPI.on('rtm.start', function(result){
-                                    Users.fetch().then(function(){
-                                        var usersStatusOnStart = {};
-
-                                        result.users.forEach(function(user){
-                                            usersStatusOnStart[user.id] = user.presence;
-                                        });
-                                        _this._getUsersData(usersStatusOnStart);
-                                    }).catch(function(){
-                                        Notify.error('Ошибка загрузки списка пользователей!');
-                                    });
-                                });
-                                break;
-
-                            case 'conference':
-                                break;
-
-                            default:
-
-                        }
-
                         this._initializeLists();
                         this._setupMessageManager();
                     }
@@ -96,25 +67,32 @@ modules.define(
             _initializeLists : function(){
                 var _this = this;
 
-                chatAPI.on('rtm.start', function(result){
-                    if(_this.getMod('type') === 'channels'){
-                        _this._getChannelsData();
-                    } else{
-                        Users.fetch()
-                            .then(function(){
+                switch(_this.getMod('type')) {
+                    case 'channels':
+                        this._getChannelsData();
+                        break;
+
+                    case 'users':
+                        chatAPI.on('rtm.start', function(result){
+                            Users.fetch().then(function(){
                                 var usersStatusOnStart = {};
 
                                 result.users.forEach(function(user){
                                     usersStatusOnStart[user.id] = user.presence;
                                 });
-
                                 _this._getUsersData(usersStatusOnStart);
-                            })
-                            .catch(function(){
+                            }).catch(function(){
                                 Notify.error('Ошибка загрузки списка пользователей!');
                             });
-                    }
-                });
+                        });
+                        break;
+
+                    case 'conference':
+                        break;
+
+                    default:
+
+                }
             },
 
             _getChannelsData : function(){
@@ -238,16 +216,19 @@ modules.define(
                     updateUsersStatus('presence_change', data);
                 });
             },
+
             _onItemClick : function(e){
                 var item = $(e.currentTarget);
                 var type = this.getMod(item, 'type');
+                var counter = this._getItemCounter(this.elemParams(item).id);
 
-                if(type == 'channels') {
+                if(type == 'channels'){
                     location.hash = e.target.innerText;
                 }
 
-                var counter = this._getItemCounter(this.elemParams(item).id);
-                counter.text('');
+                if(counter){
+                    counter.text('');
+                }
 
                 this.__self.instances.forEach(function(list){
                     list.delMod(list.elem('item'), 'current');

--- a/frontend/common.blocks/textarea/textarea.styl
+++ b/frontend/common.blocks/textarea/textarea.styl
@@ -6,7 +6,7 @@
     display block
     border none
     font 13px Arial
-    padding 9px 40px 9px 13px
+    padding 9px 50px 9px 13px
     outline none
     border-top 1px solid #efefef
     background $light_gray_color

--- a/frontend/common.blocks/user/user.styl
+++ b/frontend/common.blocks/user/user.styl
@@ -1,4 +1,4 @@
 .user
     margin 1px 0
-    display flex
+    display inline-flex
     align-items center


### PR DESCRIPTION
- С помощью RTM отслеживаются все входящие сообщения
- Если сообщение предназначено для выбранного канала, оно добавляется в историю
- Если сообщение предназначено для неактивного канала, к нему добавляется счетчик новых сообщений, который инкрементится с каждым новым сообщением
- При открытии канала с непрочитанными сообщениями, выполняется запрос к API для пометки сообщений канала как "прочитанные", обнуляется счетчик
- Отображение количества непрочитанных сообщений при загрузке не сделано, необходимо при загрузке, помимо списка каналов, для каждого вызывать метод `channels.info`. Думаю можно пока на это забить
