### PR TITLE
fix #130: Ошибка загрузки списка пользователей

### DIFF
--- a/frontend/common.blocks/dialog/dialog.js
+++ b/frontend/common.blocks/dialog/dialog.js
@@ -30,7 +30,7 @@ modules.define(
 
             _subscribeMessageUpdate : function(){
                 var _this = this;
-                var messageManager = channels('message-manager');
+                var shrimingEvents = channels('shriming-events');
                 var generatedMessage;
 
                 chatAPI.on('message',function(data){
@@ -40,7 +40,7 @@ modules.define(
                         BEMDOM.append(_this.container, generatedMessage);
                         _this._scrollToBottom();
                     }else{
-                        messageManager.emit('channel-received-message', { channelId : data.channel });
+                        shrimingEvents.emit('channel-received-message', { channelId : data.channel });
                     }
                 });
             },

--- a/frontend/common.blocks/i-users/i-users.js
+++ b/frontend/common.blocks/i-users/i-users.js
@@ -3,8 +3,8 @@
  * @description Коллекция пользователей
  */
 
-modules.define('i-users', ['i-chat-api'],
-    function(provide, chatAPI){
+modules.define('i-users', ['i-chat-api', 'events__channels'],
+    function(provide, chatAPI, channels){
         var BOT_PROFILE = {
             is_bot : true,
             name : 'slackbot',
@@ -15,6 +15,8 @@ modules.define('i-users', ['i-chat-api'],
                 image_48 : 'static/images/bot_48.png'
             }
         };
+
+        var shrimingEvents = channels('shriming-events');
 
         var Users = {
             /**
@@ -30,6 +32,7 @@ modules.define('i-users', ['i-chat-api'],
                     if(data.members && data.members.length) {
                         data.members.forEach(function(member){
                             _this._users[member.id] = member;
+                            shrimingEvents.emit('users-loaded');
                         });
                     }
                 });

--- a/frontend/common.blocks/list/list.js
+++ b/frontend/common.blocks/list/list.js
@@ -16,16 +16,12 @@ modules.define(
                             spinBlock.setMod('visible');
                         }
 
-                        this._initializeLists();
-                        this._setupMessageManager();
+                        var shrimingEvents = channels('shriming-events');
+
+                        shrimingEvents.on('users-loaded', this._initializeLists, this);
+                        shrimingEvents.on('channel-received-message', this._handleNewMessage, this);
                     }
                 }
-            },
-
-            _setupMessageManager : function(){
-                var messageManager = channels('message-manager');
-
-                messageManager.on('channel-received-message', this._handleNewMessage, this);
             },
 
             _handleNewMessage : function(e, data){
@@ -74,16 +70,13 @@ modules.define(
 
                     case 'users':
                         chatAPI.on('rtm.start', function(result){
-                            Users.fetch().then(function(){
-                                var usersStatusOnStart = {};
+                            var usersStatusOnStart = {};
 
-                                result.users.forEach(function(user){
-                                    usersStatusOnStart[user.id] = user.presence;
-                                });
-                                _this._getUsersData(usersStatusOnStart);
-                            }).catch(function(){
-                                Notify.error('Ошибка загрузки списка пользователей!');
+                            result.users.forEach(function(user){
+                                usersStatusOnStart[user.id] = user.presence;
                             });
+
+                            _this._getUsersData(usersStatusOnStart);
                         });
                         break;
 

--- a/frontend/common.blocks/page/page.js
+++ b/frontend/common.blocks/page/page.js
@@ -1,19 +1,25 @@
-modules.define('page', ['i-bem__dom', 'i-chat-api', 'socket-io'],
-    function(provide, BEMDOM, chatAPI, io){
+modules.define('page', ['i-bem__dom', 'i-chat-api', 'socket-io', 'i-users'],
+    function(provide, BEMDOM, chatAPI, io, Users){
         provide(BEMDOM.decl(this.name, {
             onSetMod : {
                 'js' : {
                     'inited' : function(){
                         var _this = this;
+
                         io.socket.on('activeUsersUpdated', function(users){
                             console.log('Active users: ', users);
                             _this._activeUsersUpdated = users;
                             _this.emit('activeUsersUpdated', users);
                         });
+
                         if(this.hasMod('logged')) {
                             if(!chatAPI.isOpen()) {
                                 chatAPI.init();
                             }
+
+                            Users.fetch().catch(function(){
+                                Notify.error('Ошибка загрузки списка пользователей!');
+                            });
                         }
                     }
                 }


### PR DESCRIPTION
Проблема началась после автоматической загрузки истории канала general при старте приложения.
Коллекция пользователей еще не успевала приехать, а история сообщений уже пыталась рендериться.
- Переименовал канал событий в `shriming-events`
- Добавил туда еще одно событие - загрузка коллекции пользователей
- При загрузке пользователей даю зеленый свет на загрузку всех остальных данных (списки каналов, история сообщений)
